### PR TITLE
Support 2x5 signals

### DIFF
--- a/CreateH5files.py
+++ b/CreateH5files.py
@@ -514,7 +514,7 @@ def process_files(settings):
                 matcher.add_fsrs(FSRs)
             if settings['Debug']:
                 matcher.set_property('Debug', True)
-            matcher.set_property('nMatchedJets', len(quark_labels) * 2)
+            matcher.set_property('maxNmatchedJets', len(quark_labels) * 2)
             matcher.set_property('MatchingCriteria',
                                  settings['MatchingCriteria'])
             if settings['MatchingCriteria'] != "UseFTDeltaRvalues":

--- a/CreateH5files.py
+++ b/CreateH5files.py
@@ -444,27 +444,27 @@ def process_files(settings):
                 Quarks[iquark].set_barcode(quark_barcode)
                 Quarks[iquark].set_pdgid(quark_pdgid)
 
-            # Select FSR quarks from gluinos
-            log.debug('Get FSRs from gluinos')
-            FSRs = [RPVParton() for i in range(nFSRsFromGs)]
-            for iFSR in range(nFSRsFromGs):
-                FSRs[iFSR].SetPtEtaPhiE(tree.truth_FSRFromGluinoQuark_pt[iFSR], tree.truth_FSRFromGluinoQuark_eta[iFSR],
-                                                   tree.truth_FSRFromGluinoQuark_phi[iFSR], tree.truth_FSRFromGluinoQuark_e[iFSR])
-                # Find quark which emitted this FSR and get its parentBarcode
-                quark_found = False
-                for parton in Quarks:
-                    if parton.get_barcode() == tree.truth_FSRFromGluinoQuark_LastQuarkInChain_barcode[iFSR]:
-                        quark_found = True
-                        FSRs[iFSR].set_gluino_barcode(
-                            parton.get_gluino_barcode())
-                        FSRs[iFSR].set_pdgid(parton.get_pdgid())
-                if not quark_found:
-                    log.fatal('Quark from gluino that emitted FSR (iFSR = {}) not found, exiting'.format(iFSR))
-                    sys.exit(1)
-                FSRs[iFSR].set_barcode(
-                    tree.truth_FSRFromGluinoQuark_barcode[iFSR])
-                FSRs[iFSR].set_quark_barcode(
-                    tree.truth_FSRFromGluinoQuark_LastQuarkInChain_barcode[iFSR])
+            if settings['useFSRs']:  # select FSR quarks from gluinos
+              log.debug('Get FSRs from gluinos')
+              FSRs = [RPVParton() for i in range(nFSRsFromGs)]
+              for iFSR in range(nFSRsFromGs):
+                  FSRs[iFSR].SetPtEtaPhiE(tree.truth_FSRFromGluinoQuark_pt[iFSR], tree.truth_FSRFromGluinoQuark_eta[iFSR],
+                                                     tree.truth_FSRFromGluinoQuark_phi[iFSR], tree.truth_FSRFromGluinoQuark_e[iFSR])
+                  # Find quark which emitted this FSR and get its parentBarcode
+                  quark_found = False
+                  for parton in Quarks:
+                      if parton.get_barcode() == tree.truth_FSRFromGluinoQuark_LastQuarkInChain_barcode[iFSR]:
+                          quark_found = True
+                          FSRs[iFSR].set_gluino_barcode(
+                              parton.get_gluino_barcode())
+                          FSRs[iFSR].set_pdgid(parton.get_pdgid())
+                  if not quark_found:
+                      log.fatal('Quark from gluino that emitted FSR (iFSR = {}) not found, exiting'.format(iFSR))
+                      sys.exit(1)
+                  FSRs[iFSR].set_barcode(
+                      tree.truth_FSRFromGluinoQuark_barcode[iFSR])
+                  FSRs[iFSR].set_quark_barcode(
+                      tree.truth_FSRFromGluinoQuark_LastQuarkInChain_barcode[iFSR])
 
             # Add quarks from neutralinos
             log.debug('Adding quarks from neutralinos')
@@ -483,8 +483,7 @@ def process_files(settings):
                 Quarks[iquark].set_barcode(quark_barcode)
                 Quarks[iquark].set_pdgid(quark_pdgid)
 
-            if signal_model == '2x5':
-                # Select FSR quarks from neutralinos
+            if signal_model == '2x5' and settings['useFSRs']:  # select FSR quarks from neutralinos
                 log.debug('Get FSRs from neutralinos')
                 FSRs += [RPVParton() for i in range(nFSRsFromNeutralinos)]
                 for iFSR in range(nFSRsFromGs, nFSRsFromNeutralinos + nFSRsFromGs):
@@ -530,7 +529,8 @@ def process_files(settings):
             # Check if fully matched
             n_matched_jets = sum(
                 [1 if jet.is_matched() else 0 for jet in matched_jets])
-            if n_matched_jets == 6:
+            log.debug(f'number of matched jets = {n_matched_jets}')
+            if n_matched_jets == len(quark_labels) * 2:
                 matchedEventNumbers.append(tree.eventNumber)
                 matchedEvents += 1
 

--- a/CreateH5files.py
+++ b/CreateH5files.py
@@ -293,27 +293,6 @@ def process_files(settings):
     for counter, event in enumerate(tree):
         log.debug('Processing eventNumber = {}'.format(tree.eventNumber))
         
-        # Skip events with any number of electrons/muons
-        # if tree.nBaselineElectrons or tree.nBaselineMuons:
-        #    continue
-
-        # # Skip events not passing event-level jet cleaning cut
-        # if not tree.DFCommonJets_eventClean_LooseBad:
-        #    continue
-        
-        # # Skip dijet events without truth branches because likely low pt cut designed to remove pileup removed these events
-        # if settings["sample"] == "Dijet" and not tree.GetBranchStatus("truth_jet_pt"):
-        #     continue
-
-        # # Skip dijet events with truth cleaning for pileup
-        # if settings["sample"] == "Dijet" and len(tree.truth_jet_pt) >= 0 and len(tree.jet_pt) >= 2:
-        #     try:
-        #         if not (1.4*tree.truth_jet_pt[0] > (tree.jet_pt[0]+tree.jet_pt[1])/2):
-        #             continue
-        #     except:
-        #         print("Pileup cleaning based on truth and reco jet pts failed. Skipping event.")
-        #         continue
-            
         # Select reco jets
         AllPassJets = []
         for ijet in range(len(tree.jet_pt)):

--- a/CreateH5files.py
+++ b/CreateH5files.py
@@ -188,14 +188,6 @@ def get_quark_flavour(quark_labels, pdgid, g, dictionary):
                 qFlavour = qlabel
         else:
             qFlavour = qlabel
-    #if dictionary[g]['q1'] == 0:
-    #    dictionary[g]['q1'] = pdgid
-    #    qFlavour = 'q1'
-    #elif dictionary[g]['q2'] == 0:
-    #    dictionary[g]['q2'] = pdgid
-    #    qFlavour = 'q2'
-    #else:
-    #    qFlavour = 'q3'
     return dictionary, qFlavour
 
 
@@ -267,8 +259,6 @@ def process_files(settings):
             Structure[gcase] = ['mask']
             Structure[gcase] += quark_labels
             Structure[gcase] += [label.replace('q', 'f') for label in quark_labels]
-        #Structure['g1'] = ['mask', 'q1', 'q2', 'q3', 'f1', 'f2', 'f3']
-        #Structure['g2'] = ['mask', 'q1', 'q2', 'q3', 'f1', 'f2', 'f3']
         Structure['EventVars'].append('gmass')
 
         # Reconstructed mass by truth mass
@@ -452,8 +442,8 @@ def process_files(settings):
                 Quarks[iquark].set_pdgid(quark_pdgid)
 
             # Select FSR quarks from gluinos
-            FSRsFromGluinos = [RPVParton() for i in range(nFSRsFromGs)]
             log.debug('Get FSRs from gluinos')
+            FSRsFromGluinos = [RPVParton() for i in range(nFSRsFromGs)]
             for iFSR in range(nFSRsFromGs):
                 FSRsFromGluinos[iFSR].SetPtEtaPhiE(tree.truth_FSRFromGluinoQuark_pt[iFSR], tree.truth_FSRFromGluinoQuark_eta[iFSR],
                                                    tree.truth_FSRFromGluinoQuark_phi[iFSR], tree.truth_FSRFromGluinoQuark_e[iFSR])
@@ -496,6 +486,7 @@ def process_files(settings):
                 matcher.add_fsrs(FSRsFromGluinos)
             if settings['Debug']:
                 matcher.set_property('Debug', True)
+            matcher.set_property('nMatchedJets', len(quark_labels) * 2)
             matcher.set_property('MatchingCriteria',
                                  settings['MatchingCriteria'])
             if settings['MatchingCriteria'] != "UseFTDeltaRvalues":
@@ -593,8 +584,8 @@ def process_files(settings):
         outFile.Close()
 
         # print matching efficiency
-        log.info(f'matching efficiency (percentage of events where 6 quarks are matched): {matchedEvents/event_counter}')
-        log.info(f'Number of events where 6 quarks are matched: {matchedEvents}')
+        log.info(f'matching efficiency (percentage of events where {len(quark_labels) * 2} quarks are matched): {matchedEvents/event_counter}')
+        log.info(f'Number of events where {len(quark_labels) * 2} quarks are matched: {matchedEvents}')
         log.info(f'percentage of events having a quark matching several jets: {multipleQuarkMatchingEvents/event_counter}')
         for flav in quark_flavours:
             if NquarksByFlavour[flav] != 0:

--- a/CreateH5files.py
+++ b/CreateH5files.py
@@ -50,6 +50,7 @@ def main():
     parser.add_argument('--doOverwrite', action="store_true", help="Overwrite already existing files")
     parser.add_argument('--useOldMCEvtWeightBranch', action="store_true", default=False, help="Use mcEventWeight instead of mcEventWeightsVector")
     parser.add_argument('--doEventDisplays', action="store_true", default=False, help="Create event displays (only done if matching is performed)")
+    parser.add_argument('--nominalOnly', action="store_true", default=False, help="Process only nominal TTree (off by default)")
     args = parser.parse_args()
 
     if args.debug:
@@ -75,6 +76,8 @@ def main():
     # get list of ttrees using the first input file
     f = ROOT.TFile(input_files[0])
     treeNames = [key.GetName() for key in list(f.GetListOfKeys()) if "trees" in key.GetName()]
+    if args.nominalOnly:
+        treeNames = ['trees_SRRPV_']
     f.Close()
 
     # prepare outdir
@@ -345,7 +348,8 @@ def process_files(settings):
             if tree.jet_pt[ijet] > settings['minJetPt']:
                 jet = RPVJet()
                 jet.SetPtEtaPhiE(tree.jet_pt[ijet], tree.jet_eta[ijet], tree.jet_phi[ijet], tree.jet_e[ijet])
-                jet.set_qgtagger_bdt(tree.jet_JetQGTaggerBDT_score[ijet]) #tree.jet_QGTagger_bdt[ijet])
+                if tree.FindBranch('jet_JetQGTaggerBDT_score'):
+                    jet.set_qgtagger_bdt(tree.jet_JetQGTaggerBDT_score[ijet]) #tree.jet_QGTagger_bdt[ijet])
                 if settings['do_matching'] and settings['MatchingCriteria'] == 'UseFTDeltaRvalues':
                     jet.set_matched_parton_barcode(int(tree.jet_deltaRcut_matched_truth_particle_barcode[ijet]))
                     jet.set_matched_fsr_barcode(int(tree.jet_deltaRcut_FSRmatched_truth_particle_barcode[ijet]))


### PR DESCRIPTION
News:
- The "nQuarksPerGluino" flag was removed (it was not used)
- New "signalModel" flag (options: 2x3 and 2x5)
  - In 2x5 signals, quarks and FSRs from neutralinos are also considered (and 10 quarks are wished to be matched to jets)
- New "useOldMCEvtWeightBranch" flag to be able to use old TTrees in which mcEventWeight is available instead of mcEventWeightsVector
- New "doOverwrite" flag to improve testing/debugging (output will be overwritten).
- New "doSystematics" flag to also process systematic TTrees (off by default)
- New 'doEventDisplays' flag to make event displays (eta-phi plot) on every event:
  -  Event display 1: reco jets, quarks from gluinos/neutralinos and FSRs, all colored by pt
  -  Event display 2: truth jets, quarks from gluinos/neutralinos, all colored by pt
  -  Event display 3: reco jets, quarks from gluinos/neutralinos (quarks colored by parent, i,e gluino/neutralino barcode)

This PR needs to be merged first:
https://github.com/jbossios/ATLAS_SUSY_RPVMJ_JetPartonMatcher/pull/21