### PR TITLE
Normalization Denominator and Backward compatibility for pdgID and pdgId 

### DIFF
--- a/CreateH5files.py
+++ b/CreateH5files.py
@@ -553,7 +553,7 @@ def process_files(settings):
                 quark_e = tree.truth_QuarkFromGluino_e[iquark]
                 quark_parent_barcode = tree.truth_QuarkFromGluino_ParentBarcode[iquark]
                 quark_barcode = tree.truth_QuarkFromGluino_barcode[iquark]
-                quark_pdgid = tree.truth_QuarkFromGluino_pdgID[iquark]
+                quark_pdgid = tree.truth_QuarkFromGluino_pdgId[iquark]
                 Quarks[iquark].SetPtEtaPhiE(quark_pt, quark_eta, quark_phi, quark_e)
                 Quarks[iquark].set_gluino_barcode(quark_parent_barcode)
                 Quarks[iquark].set_barcode(quark_barcode)
@@ -612,7 +612,7 @@ def process_files(settings):
                     log.fatal(f'Corresponding neutralino not found for quark {iquark} not found, exiting')
                     sys.exit(1)
                 quark_barcode = tree.truth_QuarkFromNeutralino_barcode[index]
-                quark_pdgid = tree.truth_QuarkFromNeutralino_pdgID[index]
+                quark_pdgid = tree.truth_QuarkFromNeutralino_pdgId[index]
                 Quarks += [RPVParton()]
                 Quarks[iquark].SetPtEtaPhiE(quark_pt, quark_eta, quark_phi, quark_e)
                 Quarks[iquark].set_gluino_barcode(quark_gluino_barcode)

--- a/CreateH5files.py
+++ b/CreateH5files.py
@@ -553,7 +553,10 @@ def process_files(settings):
                 quark_e = tree.truth_QuarkFromGluino_e[iquark]
                 quark_parent_barcode = tree.truth_QuarkFromGluino_ParentBarcode[iquark]
                 quark_barcode = tree.truth_QuarkFromGluino_barcode[iquark]
-                quark_pdgid = tree.truth_QuarkFromGluino_pdgId[iquark]
+                try:
+                    quark_pdgid = tree.truth_QuarkFromGluino_pdgID[iquark]
+                except:
+                    quark_pdgid = tree.truth_QuarkFromGluino_pdgId[iquark]
                 Quarks[iquark].SetPtEtaPhiE(quark_pt, quark_eta, quark_phi, quark_e)
                 Quarks[iquark].set_gluino_barcode(quark_parent_barcode)
                 Quarks[iquark].set_barcode(quark_barcode)
@@ -612,7 +615,10 @@ def process_files(settings):
                     log.fatal(f'Corresponding neutralino not found for quark {iquark} not found, exiting')
                     sys.exit(1)
                 quark_barcode = tree.truth_QuarkFromNeutralino_barcode[index]
-                quark_pdgid = tree.truth_QuarkFromNeutralino_pdgId[index]
+                try:
+                    quark_pdgid = tree.truth_QuarkFromNeutralino_pdgID[index]
+                except:
+                    quark_pdgid = tree.truth_QuarkFromNeutralino_pdgId[index]
                 Quarks += [RPVParton()]
                 Quarks[iquark].SetPtEtaPhiE(quark_pt, quark_eta, quark_phi, quark_e)
                 Quarks[iquark].set_gluino_barcode(quark_gluino_barcode)

--- a/CreateH5files.py
+++ b/CreateH5files.py
@@ -51,6 +51,7 @@ def main():
     parser.add_argument('--useOldMCEvtWeightBranch', action="store_true", default=False, help="Use mcEventWeight instead of mcEventWeightsVector")
     parser.add_argument('--doEventDisplays', action="store_true", default=False, help="Create event displays (only done if matching is performed)")
     parser.add_argument('--doSystematics', action="store_true", default=False, help="Process systematic TTrees (off by default)")
+    parser.add_argument('-n', '--normalization_denominator', default=None, help='json library for norm weights.')
     args = parser.parse_args()
 
     if args.debug:
@@ -69,8 +70,13 @@ def main():
         input_files = [i for i in input_files if not any([j for j in args.combineExcludedDSIDs if j in i])]
         return combine_h5(input_files, args.outDir, args.version)
 
-    # get sum of weights
-    sum_of_weights = get_sum_of_weights(input_files)
+    # load normalization denominators
+    if args.normalization_denominator:
+        with open(args.normalization_denominator) as f:
+          sum_of_weights = json.load(f)
+          sum_of_weights = {int(k):float(v) for k,v in sum_of_weights.items()}
+    else:
+        sum_of_weights = get_sum_of_weights(input_files)
     log.info('Sum of weights: {}'.format(sum_of_weights))
 
     # get list of ttrees using the first input file

--- a/launchGrid.py
+++ b/launchGrid.py
@@ -5,18 +5,22 @@ parser = argparse.ArgumentParser(usage=__doc__, formatter_class=argparse.Argumen
 parser.add_argument('--full', action="store_true", help="Run on full file list")
 parser.add_argument('--dry', action="store_true", help="Dry run.")
 parser.add_argument("-j", "--ncpu", default=1, help="Number of cores to use for multiprocessing.", type=int)
+parser.add_argument('--signalModel', default='2x3', type=str, help="Signal model (2x3 or 2x5)")
 ops = parser.parse_args()
 
-
-inFile = "/eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv_viaN1/PROD1/user.a\
-badea.mc16_13TeV.512858.MGPy8EG_A14NNPDF23LO_GG_rpv_UDB_2200_1400_viaN1.e8448_s3126_r10724_p5083.PROD1_trees.root/user.abadea.512858.e8448_e7400_s3126_r10724_r10726_p5083.29627300._000001.trees.root"
-if ops.full:
-    inFile = "/eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv_viaN1/PROD1/us\
-er.abadea.mc16_13TeV.512*/*.root"
+inFile = ""
+if ops.signalModel == "2x5":
+    inFile = "/eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv_viaN1/PROD1/user.abadea.mc16_13TeV.512858.MGPy8EG_A14NNPDF23LO_GG_rpv_UDB_2200_1400_viaN1.e8448_s3126_r10724_p5083.PROD1_trees.root/user.abadea.512858.e8448_e7400_s3126_r10724_r10726_p5083.29627300._000001.trees.root"
+    if ops.full:
+        inFile = "/eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv_viaN1/PROD1/user.abadea.mc16_13TeV.512*/*.root"
+elif ops.signalModel == "2x3":
+    inFile = "/eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv/PROD2/user.abadea.mc16_13TeV.504518.MGPy8EG_A14NNPDF23LO_GG_rpv_UDB_1400_squarks.e8258_s3126_r10724_p5083.PROD2_trees.root/user.abadea.504518.e8258_e7400_s3126_r10724_r10726_p5083.29777484._000001.trees.root"
+    if ops.full:
+        inFile = "/eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv/PROD2/user.abadea.mc16_13TeV.5*/*.root"
 
 for minJetPt in range(20,50,5):
     for maxNjets in range(11,17):
-        cmd = f"python CreateH5files.py -i '{inFile}' -v 01 --minJetPt {minJetPt} --maxNjets {maxNjets} --minNjets 10 --signalModel 2x5 -o ./Outputs/2x5/v01/minJetPt{minJetPt}_minNjets10_maxNjets{maxNjets}/ --doOverwrite -j {ops.ncpu}"
+        cmd = f"python CreateH5files.py -i '{inFile}' -v 01 --minJetPt {minJetPt} --maxNjets {maxNjets} --minNjets 10 --signalModel {ops.signalModel} -o ./Outputs/{ops.signalModel}/v01/minJetPt{minJetPt}_minNjets10_maxNjets{maxNjets}/ --doOverwrite -j {ops.ncpu}"
         print(cmd)
 
         if not ops.dry:

--- a/launchGrid.py
+++ b/launchGrid.py
@@ -1,0 +1,25 @@
+import subprocess
+import argparse
+
+parser = argparse.ArgumentParser(usage=__doc__, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser.add_argument('--full', action="store_true", help="Run on full file list")
+parser.add_argument('--dry', action="store_true", help="Dry run.")
+parser.add_argument("-j", "--ncpu", default=1, help="Number of cores to use for multiprocessing.", type=int)
+ops = parser.parse_args()
+
+
+inFile = "/eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv_viaN1/PROD1/user.a\
+badea.mc16_13TeV.512858.MGPy8EG_A14NNPDF23LO_GG_rpv_UDB_2200_1400_viaN1.e8448_s3126_r10724_p5083.PROD1_trees.root/user.abadea.512858.e8448_e7400_s3126_r10724_r10726_p5083.29627300._000001.trees.root"
+if ops.full:
+    inFile = "/eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv_viaN1/PROD1/us\
+er.abadea.mc16_13TeV.512*/*.root"
+
+for minJetPt in range(20,50,5):
+    for maxNjets in range(11,17):
+        cmd = f"python CreateH5files.py -i '{inFile}' -v 01 --minJetPt {minJetPt} --maxNjets {maxNjets} --minNjets 10 --signalModel 2x5 -o /eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv_viaN1/PROD1/h5/matched/v01/minJetPt{minJetPt}_minNjets10_maxNjets{maxNjets}/ --doOverwrite -j {ops.ncpu}"
+        print(cmd)
+
+        if not ops.dry:
+            process = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+            process.wait()
+            print("Success" if process.returncode == 0 else "Failed")

--- a/launchGrid.py
+++ b/launchGrid.py
@@ -16,7 +16,7 @@ er.abadea.mc16_13TeV.512*/*.root"
 
 for minJetPt in range(20,50,5):
     for maxNjets in range(11,17):
-        cmd = f"python CreateH5files.py -i '{inFile}' -v 01 --minJetPt {minJetPt} --maxNjets {maxNjets} --minNjets 10 --signalModel 2x5 -o /eos/atlas/atlascerngroupdisk/phys-susy/RPV_mutlijets_ANA-SUSY-2019-24/ntuples/tag/input/mc16e/GG_rpv_viaN1/PROD1/h5/matched/v01/minJetPt{minJetPt}_minNjets10_maxNjets{maxNjets}/ --doOverwrite -j {ops.ncpu}"
+        cmd = f"python CreateH5files.py -i '{inFile}' -v 01 --minJetPt {minJetPt} --maxNjets {maxNjets} --minNjets 10 --signalModel 2x5 -o ./Outputs/2x5/v01/minJetPt{minJetPt}_minNjets10_maxNjets{maxNjets}/ --doOverwrite -j {ops.ncpu}"
         print(cmd)
 
         if not ops.dry:


### PR DESCRIPTION
- option for normalization denominators in the form of a premade json file
- older ntuples have pdgID for some branches while newer ones exclusively use pdgId. Add compatibility for both.
- script `launchGrid.py` for launching a grid of h5 production scanning over minJetPt and NJet cuts